### PR TITLE
add files expected by GitHint

### DIFF
--- a/.githint.json
+++ b/.githint.json
@@ -10,21 +10,18 @@
             ]
         },
         "CHANGELOG": {
-            "skip": true,
             "script": "!!(tree.tree.find(t => t.path === 'CHANGELOG' || t.path === 'CHANGELOG.md'))",
             "message": [
                 "The repository must contain a CHANGELOG(.md) file"
             ]
         },
         "CODE_OF_CONDUCT": {
-            "skip": true,
             "script": "!!(tree.tree.find(t => t.path === 'CODE_OF_CONDUCT.md'))",
             "message": [
                 "The repository must contain a CODE_OF_CONDUCT.md file"
             ]
         },
         "CONTRIBUTING": {
-            "skip": true,
             "script": "!!(tree.tree.find(t => t.path === 'CONTRIBUTING.md'))",
             "message": [
                 "The repository must contain a CONTRIBUTING.md file"

--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,0 +1,13 @@
+<!--- Provide a general summary of the issue in the Title above -->
+
+## Identified Gap
+<!--- Tell us what is missing in our current engineering practices -->
+
+## Possible Solution
+<!--- Not obligatory, but suggest a possible solution to address the issue -->
+
+## Examples
+<!--- Provide some examples where the gap has manifest in the engineering teams -->
+
+## Additional Context
+<!--- Any additional context you'd like to provide? -->

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,7 @@
+#### What does this PR do?
+#### Description of task to be completed?
+#### How should this be manually tested?
+#### Any background context you want to provide?
+#### What are the relevant pivotal tracker stories?
+#### Screenshots (if appropriate)
+#### Questions:

--- a/.github/RELEASE_TEMPLATE.md
+++ b/.github/RELEASE_TEMPLATE.md
@@ -1,0 +1,25 @@
+`title: <release-date: yyyy-mm-dd>, Version <x.x.x>`
+
+## New Guidelines
+
+>You can exclude this section if there are no new guidelines
+
+- **Section Title (eg. Developing)**: Guideline name (and short description), `#<pr-number>`
+- etc
+
+## Updates
+
+- **Section Title (eg. Developing)**: Update made, `#<pr-number>`
+- etc.
+
+## Fixes
+
+- **Section Title (eg. Developing)**: Update made, `#<pr-number>`
+- etc.
+
+## Credits
+
+>List contributors who were involved in the changes for the release, including reviewers.
+
+- Name (@gh-handle)
+- etc

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,74 @@
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+
+In the interest of fostering an open and welcoming environment, we as
+contributors and maintainers pledge to making participation in our project and
+our community a harassment-free experience for everyone, regardless of age, body
+size, disability, ethnicity, gender identity and expression, level of experience,
+education, socio-economic status, nationality, personal appearance, race,
+religion, or sexual identity and orientation.
+
+## Our Standards
+
+Examples of behavior that contributes to creating a positive environment
+include:
+
+* Using welcoming and inclusive language
+* Being respectful of differing viewpoints and experiences
+* Gracefully accepting constructive criticism
+* Focusing on what is best for the community
+* Showing empathy towards other community members
+
+Examples of unacceptable behavior by participants include:
+
+* The use of sexualized language or imagery and unwelcome sexual attention or
+  advances
+* Trolling, insulting/derogatory comments, and personal or political attacks
+* Public or private harassment
+* Publishing others' private information, such as a physical or electronic
+  address, without explicit permission
+* Other conduct which could reasonably be considered inappropriate in a
+  professional setting
+
+## Our Responsibilities
+
+Project maintainers are responsible for clarifying the standards of acceptable
+behavior and are expected to take appropriate and fair corrective action in
+response to any instances of unacceptable behavior.
+
+Project maintainers have the right and responsibility to remove, edit, or
+reject comments, commits, code, wiki edits, issues, and other contributions
+that are not aligned to this Code of Conduct, or to ban temporarily or
+permanently any contributor for other behaviors that they deem inappropriate,
+threatening, offensive, or harmful.
+
+## Scope
+
+This Code of Conduct applies both within project spaces and in public spaces
+when an individual is representing the project or its community. Examples of
+representing a project or community include using an official project e-mail
+address, posting via an official social media account, or acting as an appointed
+representative at an online or offline event. Representation of a project may be
+further defined and clarified by project maintainers.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be
+reported by contacting the project team at chieze.franklin@gmail.com. All
+complaints will be reviewed and investigated and will result in a response that
+is deemed necessary and appropriate to the circumstances. The project team is
+obligated to maintain confidentiality with regard to the reporter of an incident.
+Further details of specific enforcement policies may be posted separately.
+
+Project maintainers who do not follow or enforce the Code of Conduct in good
+faith may face temporary or permanent repercussions as determined by other
+members of the project's leadership.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage], version 1.4,
+available at https://www.contributor-covenant.org/version/1/4/code-of-conduct.html
+
+[homepage]: https://www.contributor-covenant.org
+

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,39 @@
+## Contributing
+
+[fork]: /fork
+[pr]: /compare
+[style]: https://github.com/airbnb/javascript
+[code-of-conduct]: CODE_OF_CONDUCT.md
+
+Hi there! We're thrilled that you'd like to contribute to this project. Your help is essential for keeping it great.
+
+Please note that this project is released with a [Contributor Code of Conduct][code-of-conduct]. By participating in this project you agree to abide by its terms.
+
+## Issues and PRs
+
+If you have suggestions for how this project could be improved, or want to report a bug, open an issue! We'd love all and any contributions. If you have questions, too, we'd love to hear them.
+
+We'd also love PRs. If you're thinking of a large PR, we advise opening up an issue first to talk about it, though! Look at the links below if you're not sure how to open a PR.
+
+## Submitting a pull request
+
+1. [Fork][fork] and clone the repository.
+1. Create a new branch: `git checkout -b my-branch-name`.
+1. Push to your fork and [submit a pull request][pr].
+1. Make sure the GitHint checks still pass.
+1. Pat your self on the back and wait for your pull request to be reviewed and merged.
+
+Here are a few things you can do that will increase the likelihood of your pull request being accepted:
+
+- Follow the [style guide][style] which is using standard. Any linting errors should be shown when running `npm test`.
+- Write and update tests.
+- Keep your changes as focused as possible. If there are multiple changes you would like to make that are not dependent upon each other, consider submitting them as separate pull requests.
+- Write a [good commit message](https://github.com/andela/engineering-playbook/tree/master/5.%20Developing/Conventions#commit-message).
+
+Work in Progress pull requests are also welcome to get feedback early on, or if there is something blocked you.
+
+## Resources
+
+- [How to Contribute to Open Source](https://opensource.guide/how-to-contribute/)
+- [Using Pull Requests](https://help.github.com/articles/about-pull-requests/)
+- [GitHub Help](https://help.github.com)


### PR DESCRIPTION

#### What does this PR do?

add files expected by GitHint

#### Description of task to be completed?

- add .github directory to contain:
-- ISSUE_TEMPLATE.md
-- PULL_REQUEST_TEMPLATE.md
-- REALEASE_TEMPLATE.md
- add CHANGELOG.md
- add CODE_OF_CONDUCT.md
- add CONTRIBUTING.md

[Finishes #167171075]

#### How should this be manually tested?
#### Any background context you want to provide?
#### What are the relevant pivotal tracker stories?
#### Screenshots (if appropriate)
#### Questions: